### PR TITLE
Add rel="me" to social links for validation

### DIFF
--- a/layouts/partials/sns-links.html
+++ b/layouts/partials/sns-links.html
@@ -8,7 +8,7 @@
 
   {{- else if and $social (ne $value true)  -}}
     {{ $social = merge $social (dict "id" $value) }}
-    
+
   {{- else if $value -}}
   {{- else -}}
   {{ $social = dict }}
@@ -34,7 +34,7 @@
 {{ $destination = printf (string .format) .id }}
 {{- end -}}
 <li>
-  <a href="{{ $destination | safeURL }}" {{- if (urls.Parse $destination).Host | or .newtab }} target="_blank" {{- end -}}>
+  <a rel="me" href="{{ $destination | safeURL }}" {{- if (urls.Parse $destination).Host | or .newtab }} target="_blank" {{- end -}}>
     <span class="fa-stack fa-lg">
       <i class="fa fa-circle fa-stack-2x"></i>
       <i class="{{ .icon }} fa-stack-1x fa-inverse">{{- .text -}}</i>


### PR DESCRIPTION
Mastodon profile metadata requires a link on your website in the format of `<a rel="me" href="foo.com">Link text</a>` to validate that you are the owner of that link. Placing this on all social links since the definition of the _me_ value is: _"Indicates that the current document represents the person who owns the linked content"_ and social links are owned by the person/entity for the Hugo-generated website.