### PR TITLE
Fix deprecation warnings

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -16,8 +16,11 @@ enableEmoji = true
 # See https://github.com/gohugoio/hugo/issues/7228#issuecomment-714490456
 ignoreErrors = ["error-remote-getjson"]
 
-disqusShortname = ""
-googleAnalytics = ""
+[services]
+[services.disqus]
+shortname = ''
+[services.googleAnalytics]
+id = ''
 
 [outputs]
 home = ["HTML", "JSON", "RSS"]

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,6 +1,6 @@
 {{ if (ne .Params.comment false) -}}
 
-{{ if .Site.DisqusShortname }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
 {{ template "_internal/disqus.html" . }}
 {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -91,8 +91,7 @@
 
 {{ end }}
 
-
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.106.0"
+  HUGO_VERSION = "0.124.1"
 
 [context.production.environment]
   HUGO_BASEURL = "https://hugo-theme-puppet.netlify.app/"


### PR DESCRIPTION
When running with latest hugo version 0.124.1, deprecating warnings are printed out:

```
INFO  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
INFO  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.
```

This PR fixes these issues.