### PR TITLE
fix: for hugo v0.136.5

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -4,7 +4,7 @@
 {{ template "_internal/disqus.html" . }}
 {{ end }}
 
-{{ $giscus := .Site.Params.giscus }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
 {{ if $giscus.enable }}
 <div class="giscus" id="comments"></div>
 <script src="https://giscus.app/client.js" 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -92,7 +92,7 @@
 {{ end }}
 
 
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 


### PR DESCRIPTION
WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.