### PR TITLE
fix: for hugo v0.136.5

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,7 +27,7 @@
 
   {{ $options := (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction) "includePaths" (slice
   "sass")) }}
-  {{- $style := resources.Get "sass/main.scss" | resources.ToCSS $options -}}
+  {{- $style := resources.Get "sass/main.scss" | css.Sass $options -}}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
   {{ $zoom_css := resources.Get "zoomjs/zoom.css" | resources.Minify -}}
@@ -36,7 +36,7 @@
   {{ range .Site.Params.custom_css -}}
   {{ $custom_template := resources.Get . }}
   {{ if $custom_template }}
-  {{ $custom_style := $custom_template | resources.ToCSS | resources.Minify }}
+  {{ $custom_style := $custom_template | css.Sass | resources.Minify }}
   <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}">
   {{ end }}
   {{- end -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,6 +10,9 @@
               col-lg-8 col-lg-offset-2
               col-md-10 col-md-offset-1
               post-container">
+
+        <span id="busuanzi_container_page_pv">Total Views: <span id="busuanzi_value_page_pv"></span></span>
+        
         {{ .Content }}
 
         <hr style="visibility: hidden;" />

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,6 +1,6 @@
 {{ if (ne .Params.comment false) -}}
 
-{{ if .Site.DisqusShortname }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
 {{ template "_internal/disqus.html" . }}
 {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -92,7 +92,7 @@
 {{ end }}
 
 
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 

--- a/layouts/partials/tagcloud.html
+++ b/layouts/partials/tagcloud.html
@@ -23,7 +23,7 @@
 {{ $sassTemplate := resources.Get "sass/tagcolor-template.scss" }}
 {{ $params := dict "weighting" (sub . $min) "spread" $spread "count" .  }}
 
-{{ $style := $sassTemplate | resources.ExecuteAsTemplate (printf "tagscolors__%d.css" .) $params | resources.ToCSS }}
+{{ $style := $sassTemplate | resources.ExecuteAsTemplate (printf "tagscolors__%d.css" .) $params | css.Sass }}
 {{ with $style }}
   {{ .Content | safeCSS }}
 {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.106.0"
+  HUGO_VERSION = "0.136.5"
 
 [context.production.environment]
   HUGO_BASEURL = "https://hugo-theme-puppet.netlify.app/"


### PR DESCRIPTION
ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.137.0. Use .Site.Config.Services.Disqus.Shortname instead.